### PR TITLE
Add 'eu-west-2c' availability zone to db

### DIFF
--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -24,6 +24,7 @@ module "grafana_ecs" {
   grafana_build              = true
   project                    = var.project
   vpc_private_subnet_ids     = data.aws_subnet_ids.private.ids
+  vpc_id                     = data.aws_vpc.main.id
 }
 
 module "grafana_certificate" {

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -6,6 +6,6 @@ locals {
     "Terraform", true,
     "CostCentre", data.aws_ssm_parameter.cost_centre.value
   )
-  database_availability_zones = ["eu-west-2a", "eu-west-2b"]
+  database_availability_zones = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
   environment                 = "mgmt"
 }


### PR DESCRIPTION
Fixed issue after tdr-terraform-modules updated to make vpc id variable required for ecs