### PR TITLE
Fetch IP allow list from tdr-configurations instead of SSM param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+tdr-configurations
 tdr-terraform-modules
 .terraform

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ The docker container runs with the pre-defined `grafana` user.
 
 This user is part of the `root` group, but *does not* have root user permissions.
 
+## Local development
+
+If this is the first time you have run this project, clone the [modules](https://github.com/nationalarchives/tdr-terraform-modules) and [configurations](https://github.com/nationalarchives/tdr-configurations) repos into the terraform directory.
+
+Otherwise, pull the latest version of master for those repos.
+
 ## Deployment
 
 There is a Jenkins job configured to deploy changes to the Grafana configuration: https://jenkins.tdr-management.nationalarchives.gov.uk/job/TDR%20Grafana%20Deploy/

--- a/terraform/modules/grafana/security.tf
+++ b/terraform/modules/grafana/security.tf
@@ -2,10 +2,6 @@ locals {
   app_port = 3000
 }
 
-data "aws_ssm_parameter" "external_ips" {
-  name = "/${var.environment}/external_ips"
-}
-
 resource "aws_security_group" "grafana_alb_group" {
   name        = "tdr-grafana-alb-security-group"
   description = "Controls access to the Grafana load balancer"
@@ -14,7 +10,7 @@ resource "aws_security_group" "grafana_alb_group" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = split(",", data.aws_ssm_parameter.external_ips.value)
+    cidr_blocks = var.ip_allowlist
   }
 
   egress {

--- a/terraform/modules/grafana/variables.tf
+++ b/terraform/modules/grafana/variables.tf
@@ -14,6 +14,10 @@ variable "ecs_task_role_name" {}
 
 variable "environment" {}
 
+variable "ip_allowlist" {
+  type = list
+}
+
 variable "kms_key_id" {}
 
 variable "vpc_cidr_block" {}

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -1,3 +1,7 @@
+module "global_parameters" {
+  source = "./tdr-configurations/terraform"
+}
+
 module "grafana" {
   source = "./modules/grafana"
 
@@ -9,6 +13,7 @@ module "grafana" {
   dns_zone                    = var.dns_zone
   ecs_task_role_name          = module.grafana_ecs.grafana_ecs_task_role_name
   environment                 = local.environment
+  ip_allowlist                = local.ip_allowlist
   kms_key_id                  = module.encryption_key.kms_key_arn
   vpc_cidr_block              = data.aws_vpc.main.cidr_block
   vpc_id                      = data.aws_vpc.main.id

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -8,4 +8,8 @@ locals {
   )
   database_availability_zones = ["eu-west-2a", "eu-west-2b"]
   environment                 = "mgmt"
+
+  developer_ip_list = split(",", module.global_parameters.developer_ips)
+  trusted_ip_list   = split(",", module.global_parameters.trusted_ips)
+  ip_allowlist      = concat(local.developer_ip_list, local.trusted_ip_list)
 }


### PR DESCRIPTION
This changes where the list of IPs which are allowed to access Grafana is read from.

Before, we read the list from a parameter in the AWS SSM Parameter Store. Now, it reads the list from the tdr-configurations repo.

The tdr-configurations repo was already being used for the frontend load balancer allow list, so this change makes Grafana consistent with tdr-terraform-environments.

It also reduces the number of deployment steps. When the list changes, we can now deploy the changes by running this Terraform project, without having to deploy the change to the parameter store first.