### PR TITLE
Upgrade Postgres database to version 11.9

### DIFF
--- a/terraform/modules/grafana/database.tf
+++ b/terraform/modules/grafana/database.tf
@@ -24,7 +24,7 @@ resource "random_string" "snapshot_prefix" {
 resource "aws_rds_cluster" "grafana_database" {
   cluster_identifier_prefix       = "grafana-db-postgres-${var.environment}"
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.6"
+  engine_version                  = "11.9"
   availability_zones              = var.database_availability_zones
   database_name                   = "grafana"
   master_username                 = "grafana_admin"
@@ -57,7 +57,7 @@ resource "aws_rds_cluster_instance" "user_database_instance" {
   identifier_prefix    = "content-db-postgres-instance-${var.environment}"
   cluster_identifier   = aws_rds_cluster.grafana_database.id
   engine               = "aurora-postgresql"
-  engine_version       = "11.6"
+  engine_version       = "11.9"
   instance_class       = "db.t3.medium"
   db_subnet_group_name = aws_db_subnet_group.user_subnet_group.name
 }


### PR DESCRIPTION
Upgrade the Grafana PostgreSQL database from version 11.6 to 11.9.

The database has already been upgraded in all AWS environments, so this change just brings the Terraform in line with the deployed configuration.