### PR TITLE
Allow listening on port 80

### DIFF
--- a/terraform/modules/grafana/security.tf
+++ b/terraform/modules/grafana/security.tf
@@ -13,6 +13,13 @@ resource "aws_security_group" "grafana_alb_group" {
     cidr_blocks = var.ip_allowlist
   }
 
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = var.ip_allowlist
+  }
+
   egress {
     protocol    = "-1"
     from_port   = 0


### PR DESCRIPTION
To enable http -> https redirect load-balancer security group needs to allow traffic on port 80