### PR TITLE
Upgrade aws provider 3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,6 @@ terraformDeployJob(
   repo: "tdr-grafana",
   taskRoleName: "TDRTerraformRoleMgmt",
   deployment: "Grafana",
-  terraformDirectoryPath: "./terraform"
+  terraformDirectoryPath: "./terraform",
+  modulesBranch: "update-aws-provider-version-support"
 )

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "2.69"
+      version = "3.48"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Requires PR: https://github.com/nationalarchives/tdr-jenkinslib/pull/61

Will temporarily reference the `update-aws-provider-version-support` tdr-terraform-modules branch to provide backwards compatibility until all repos are upgraded to AWS provider version 3.48 (see draft PR: https://github.com/nationalarchives/tdr-terraform-modules/pull/127)
